### PR TITLE
Potential fix for code scanning alert no. 23: Incomplete URL substring sanitization

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -4,7 +4,7 @@ from discord import app_commands
 
 import yt_dlp
 import asyncio
-
+from urllib.parse import urlparse
 class MusicView(discord.ui.LayoutView):
     container = discord.ui.Container(
         discord.ui.TextDisplay("### 操作パネル"),
@@ -153,7 +153,9 @@ class MusicCog(commands.Cog):
                             if interaction.user.voice is None:
                                 return await interaction.response.send_message("ボイスチャンネルに参加してください。")
 
-                            if not "soundcloud.com" in self_.musicurl.component.value:
+                            parsed_url = urlparse(self_.musicurl.component.value)
+                            host = parsed_url.hostname
+                            if not (host == "soundcloud.com" or (host and host.endswith(".soundcloud.com"))):
                                 return await interaction.response.send_message("SoundCloud以外に対応していません。")
                             
                             await interaction.response.defer()


### PR DESCRIPTION
Potential fix for [https://github.com/SharkBot-Dev/SharkBot-v2/security/code-scanning/23](https://github.com/SharkBot-Dev/SharkBot-v2/security/code-scanning/23)

To reliably restrict input to legitimate SoundCloud URLs, we should **parse the user-supplied URL** and then check that its **hostname** is exactly `soundcloud.com` or ends with `.soundcloud.com`. This is the recommended and secure way, as per the examples provided. We can use Python’s standard library `urllib.parse` (`urlparse`) for this. 

In `cogs/music.py`, within `MusicAddModal.on_submit`, on line 156, instead of doing a substring search, use `urllib.parse.urlparse()` on `self_.musicurl.component.value`, then check if the resulting hostname matches the required domain. If the hostname does not match, send the error message as before.

We will need to import `urlparse` (from `urllib.parse`) at the top of the file unless it already exists.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
